### PR TITLE
Barcode options were not being applied

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -318,7 +318,7 @@ impl<D: Driver> Printer<D> {
     fn barcode(&mut self, barcode: Barcode) -> Result<&mut Self> {
         let commands = self
             .protocol
-            .barcode(&barcode.data, barcode.system, BarcodeOption::default())?;
+            .barcode(&barcode.data, barcode.system, barcode.option)?;
         self.command(&format!("print {} barcode", barcode.system), commands.as_slice())
     }
 


### PR DESCRIPTION
Fixed barcode formatting, which was not being applied and being set to default. Just tested on ean8 barcode. 