### PR TITLE
implement std::error::Error for PrinterError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,8 @@ pub enum PrinterError {
     Input(String),
 }
 
+impl std::error::Error for PrinterError {}
+
 impl fmt::Display for PrinterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {


### PR DESCRIPTION
Having the std::error::Error trait is very useful when using crates like `sentry` and `anyhow` and comes almost for free, as all methods have default implementation if `Display` / `Debug` are implemented.