### PR TITLE
Bit image from bytes

### DIFF
--- a/src/domain/bit_image.rs
+++ b/src/domain/bit_image.rs
@@ -96,7 +96,17 @@ impl BitImage {
     /// Create a new image
     pub fn new(path: &str, option: BitImageOption) -> Result<Self> {
         let img = image::open(path)?;
+        Self::from_dynamic_image(img, option, path)
+    }
+  
+    /// Create a new image from bytes
+    pub fn from_bytes(bytes: &[u8], option: BitImageOption) -> Result<Self> {
+        let img = image::load_from_memory(bytes)?;
+        Self::from_dynamic_image(img, option, "")
+    }
 
+    // Create a new image from DynamicImage
+    fn from_dynamic_image(img: DynamicImage, option: BitImageOption, path: &str) -> Result<Self> {
         // Resize image with max width and max height constraints and convert to grayscale
         let mut img = match (option.max_width, option.max_height) {
             (Some(max_width), None) => {

--- a/src/domain/protocol.rs
+++ b/src/domain/protocol.rs
@@ -610,20 +610,32 @@ impl Protocol {
     #[cfg(feature = "graphics")]
     /// Print bit image
     pub(crate) fn bit_image(&self, path: &str, option: BitImageOption) -> Result<Command> {
-        let mut cmd = GS_IMAGE_BITMAP_PREFIX.to_vec();
         let bit_image = BitImage::new(path, option)?;
+        self.build_bit_image(bit_image)
+    }
 
-        // Size
-        cmd.push(bit_image.size().into());
+    #[cfg(feature = "graphics")]
+    /// Print bit image from bytes
+    pub(crate) fn bit_image_from_bytes(&self, bytes: &[u8], option: BitImageOption) -> Result<Command> {
+        let bit_image = BitImage::from_bytes(bytes, option)?;
+        self.build_bit_image(bit_image)
+    }
+    
+    #[cfg(feature = "graphics")]
+    fn build_bit_image(&self, bit_image: BitImage) -> Result<Command> {
+      let mut cmd = GS_IMAGE_BITMAP_PREFIX.to_vec();
 
-        // Width and height
-        cmd.append(&mut bit_image.with_bytes_u8()?);
-        cmd.append(&mut bit_image.height_u8()?);
+      // Size
+      cmd.push(bit_image.size().into());
 
-        // Data
-        cmd.append(&mut bit_image.raster_data()?);
+      // Width and height
+      cmd.append(&mut bit_image.with_bytes_u8()?);
+      cmd.append(&mut bit_image.height_u8()?);
 
-        Ok(cmd)
+      // Data
+      cmd.append(&mut bit_image.raster_data()?);
+
+      Ok(cmd)
     }
 
     // #[cfg(feature = "graphics")]

--- a/src/domain/protocol.rs
+++ b/src/domain/protocol.rs
@@ -623,19 +623,19 @@ impl Protocol {
     
     #[cfg(feature = "graphics")]
     fn build_bit_image(&self, bit_image: BitImage) -> Result<Command> {
-      let mut cmd = GS_IMAGE_BITMAP_PREFIX.to_vec();
+        let mut cmd = GS_IMAGE_BITMAP_PREFIX.to_vec();
 
-      // Size
-      cmd.push(bit_image.size().into());
+        // Size
+        cmd.push(bit_image.size().into());
 
-      // Width and height
-      cmd.append(&mut bit_image.with_bytes_u8()?);
-      cmd.append(&mut bit_image.height_u8()?);
+        // Width and height
+        cmd.append(&mut bit_image.with_bytes_u8()?);
+        cmd.append(&mut bit_image.height_u8()?);
 
-      // Data
-      cmd.append(&mut bit_image.raster_data()?);
+        // Data
+        cmd.append(&mut bit_image.raster_data()?);
 
-      Ok(cmd)
+        Ok(cmd)
     }
 
     // #[cfg(feature = "graphics")]

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -526,6 +526,22 @@ impl<D: Driver> Printer<D> {
         self.bit_image_option(path, BitImageOption::default())
     }
 
+    #[cfg(feature = "graphics")]
+    /// Print image
+    pub fn bit_image_option_from_bytes(&mut self, bytes: &[u8], option: BitImageOption) -> Result<&mut Self> {
+        let cmd = self.protocol.cancel();
+        self.command("cancel data", &[cmd])?;
+
+        let cmd = self.protocol.bit_image_from_bytes(bytes, option)?;
+        self.command("print bit image from bytes", &[cmd])
+    }
+
+    #[cfg(feature = "graphics")]
+    /// Print image
+    pub fn bit_image_from_bytes(&mut self, bytes: &[u8]) -> Result<&mut Self> {
+        self.bit_image_option_from_bytes(bytes, BitImageOption::default())
+    }
+
     // #[cfg(feature = "graphics")]
     // /// Print image
     // fn _image(&mut self, path: &str) -> Result<&mut Self> {


### PR DESCRIPTION
In some applications an image is not retrieved from a file, but from something like `rust_embed` or `base64`, so a possibility to print an image from bytes is useful.