### PR TITLE
Allow non-utf8 encodings to be used for Encoder

### DIFF
--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -7,28 +7,48 @@ use encoding_rs::{Encoding, UTF_8};
 #[derive(Clone)]
 pub struct Encoder {
     codec: &'static Encoding,
+    allow_unencodable: bool,
 }
 
 impl Default for Encoder {
     fn default() -> Self {
-        Encoder { codec: UTF_8 }
+        Encoder {
+            codec: UTF_8,
+            allow_unencodable: false,
+        }
     }
 }
 
 impl Encoder {
     /// Create a new encoder
     pub fn new(codec: &'static Encoding) -> Self {
-        Self { codec }
+        Self {
+            codec,
+            allow_unencodable: false,
+        }
+    }
+
+    /// Allow this encoder to succeed if the unicode text that it's encoding
+    /// can't be fully mapped to the output encoding.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// The unmappable characters will be replaced with HTML numeric character
+    /// references, as per the implementation of [`encoding_rs::Encoding::encode()`].
+    pub fn allow_unencodable(mut self, yes: bool) -> Self {
+        self.allow_unencodable = yes;
+        self
     }
 
     /// Encode string into the right codec
     pub(crate) fn encode(&self, data: &str) -> Result<Vec<u8>> {
-        match self.codec.can_encode_everything() {
-            true => Ok(self.codec.encode(data).0.into()),
-            false => Err(crate::errors::PrinterError::Input(format!(
+        let (output, _, unmappable) = self.codec.encode(data);
+        if unmappable && !self.allow_unencodable {
+            return Err(crate::errors::PrinterError::Input(format!(
                 "invalid {}",
                 self.codec.name()
-            ))),
+            )));
         }
+        Ok(output.into())
     }
 }


### PR DESCRIPTION
As of now, any encoding besides UTF-8 will simply error if used with Encoder, since it errors if [`can_encode_everything()`](https://docs.rs/encoding_rs/latest/encoding_rs/struct.Encoding.html#method.can_encode_everything) returns false, and that method only returns true for UTF-8. Instead, only error if the text can't be encoded, and allow the user to disable that behavior.