### PR TITLE
push remaining bits when breaking from bitmap creation

### DIFF
--- a/src/domain/bit_image.rs
+++ b/src/domain/bit_image.rs
@@ -244,6 +244,8 @@ impl BitImage {
 
                     // Breaking the loop if x_offset exceeds the width
                     if x_offset >= width {
+                        // put the bits in the right position before breaking
+                        byte = byte << (8 - bit);
                         break;
                     }
 


### PR DESCRIPTION
I added a line that shifts the bits to the correct position when breaking because of the image width. Fixes #41 
Here is the result (top is before, bottom is after):
![img](https://github.com/user-attachments/assets/841e00b6-0cb2-4bf5-8502-2b180a70a253)
