### PR TITLE
fix examples failing when cd'd into the examples directory

### DIFF
--- a/examples/full.rs
+++ b/examples/full.rs
@@ -5,6 +5,7 @@ use escpos::{driver::*, errors::Result};
 
 fn main() -> Result<()> {
     env_logger::init();
+    let repo_root_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
 
     // let driver = NetworkDriver::open("192.168.1.248", 9100, None)?;
     let driver = ConsoleDriver::open(true);
@@ -60,7 +61,7 @@ fn main() -> Result<()> {
         .aztec("test1245789658745")?
         .feed()?
         .bit_image_option(
-            "./resources/images/rust-logo-small.png",
+            &(repo_root_dir + "/resources/images/rust-logo-small.png"),
             BitImageOption::new(Some(128), None, BitImageSize::Normal)?,
         )?
         .feed()?

--- a/examples/pictures.rs
+++ b/examples/pictures.rs
@@ -4,6 +4,7 @@ use escpos::{driver::*, errors::Result};
 
 fn main() -> Result<()> {
     env_logger::init();
+    let repo_root_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
 
     // Picture from URL
     let picture_bytes = reqwest::blocking::get(
@@ -19,7 +20,7 @@ fn main() -> Result<()> {
     printer
         .init()?
         .justify(JustifyMode::CENTER)?
-        .bit_image("./resources/images/rust-logo-small.png")?
+        .bit_image(&(repo_root_dir + "/resources/images/rust-logo-small.png"))?
         .feed()?
         .bit_image_from_bytes_option(
             &picture_bytes,

--- a/examples/receipt.rs
+++ b/examples/receipt.rs
@@ -9,6 +9,7 @@ const NUM: &[u8] = &[0xF8]; // °
 
 fn main() -> Result<()> {
     env_logger::init();
+    let repo_root_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
 
     let items = vec![
         Item::new("Macbook Pro", Some(1), 2500.00, false),
@@ -36,7 +37,7 @@ fn main() -> Result<()> {
 
     // Logo
     #[cfg(feature = "graphics")]
-    printer.bit_image("./resources/images/rust-logo-small.png")?;
+    printer.bit_image(&(repo_root_dir + "/resources/images/rust-logo-small.png"))?;
 
     // Line
     let simple_line = LineBuilder::new().style(LineStyle::Simple).build();


### PR DESCRIPTION
Before, running the examples from the examples directory failed with a very unhelpful

> Error: Io("No such file or directory (os error 2)")

Especially when troubleshooting if escpos-rs is even correctly connecting to the printer.