### PR TITLE
fix: enable options for UsbDriver

### DIFF
--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
         );
     }
 
-    let driver = UsbDriver::open(0x0525, 0xa700, None)?;
+    let driver = UsbDriver::open(0x0525, 0xa700, None, None)?;
     Printer::new(driver, Protocol::default(), None)
         .debug_mode(Some(DebugMode::Dec))
         .init()?

--- a/src/io/driver.rs
+++ b/src/io/driver.rs
@@ -8,7 +8,7 @@ use hidapi::{HidApi, HidDevice};
 #[cfg(feature = "native_usb")]
 use nusb::transfer::RequestBuffer;
 #[cfg(feature = "usb")]
-use rusb::{Context, DeviceHandle, Direction, TransferType, UsbContext};
+use rusb::{Context, DeviceHandle, Direction, TransferType, UsbContext, UsbOption};
 #[cfg(feature = "serial_port")]
 use serialport::SerialPort;
 use std::sync::{Arc, Mutex};
@@ -238,8 +238,17 @@ impl UsbDriver {
     /// let driver = UsbDriver::open(0x0525, 0xa700, None).unwrap();
     /// let mut printer = Printer::new(driver, Protocol::default(), None);
     /// ```
-    pub fn open(vendor_id: u16, product_id: u16, timeout: Option<Duration>) -> Result<Self> {
-        let context = Context::new().map_err(|e| PrinterError::Io(e.to_string()))?;
+    pub fn open(
+        vendor_id: u16,
+        product_id: u16,
+        timeout: Option<Duration>,
+        options: Option<&[UsbOption]>,
+    ) -> Result<Self> {
+        let context = if let Some(options) = options {
+            Context::with_options(options).map_err(|e| PrinterError::Io(e.to_string()))?
+        } else {
+            Context::new().map_err(|e| PrinterError::Io(e.to_string()))?
+        };
         let devices = context.devices().map_err(|e| PrinterError::Io(e.to_string()))?;
 
         for device in devices.iter() {


### PR DESCRIPTION
Thanks for the great work on this crate — it’s been incredibly helpful. This PR adds support for using UsbDk as the USB backend on Windows. It enables rusb to work with devices that ship with non-WinUSB drivers (e.g., usbprinter), improving compatibility and flexibility for Windows users. Tested on my Windows setup.