### PR TITLE
Fix typo in command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ fn main() -> Result<()> {
 |   ✅   | `font()`                        | Text font (`ESC M`)                                   |            |
 |   ✅   | `flip()`                        | Text flip (`ESC V`)                                   |            |
 |   ✅   | `justify()`                     | Text justify (`ESC a`)                                |            |
-|   ✅   | `reserve()`                     | Text reserve color (`GS B`)                           |            |
+|   ✅   | `reverse()`                     | Text reverse color (`GS B`)                           |            |
 |   ✅   | `size()`                        | Text size (`GS !`)                                    |            |
 |   ✅   | `reset_size()`                  | Reset text size (`GS !`)                              |            |
 |   ✅   | `smoothing()`                   | Smoothing mode (`GS b`)                               |            |


### PR DESCRIPTION
Hi,

Thanks for the great work!

When using the library, I discovered a small typo with the `reverse` command in the README.