### PR TITLE
feat: add usbprint driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hidapi = ["dep:hidapi"]
 serial_port = ["dep:serialport"]
 usb = ["dep:rusb"]
 native_usb = ["dep:nusb"]
+usbprint = ["dep:windows-sys"]
 ui = []
 default = ["barcodes", "codes_2d"]
 full = [
@@ -32,6 +33,7 @@ full = [
     "native_usb",
     "hidapi",
     "serial_port",
+    "usbprint",
     "ui",
 ]
 
@@ -44,6 +46,13 @@ image = { version = "0.25.8", optional = true }
 nusb = { version = "0.2.0", optional = true }
 rusb = { version = "0.9.4", optional = true }
 serialport = { version = "4.7.3", optional = true }
+windows-sys = { version = "0.60", optional = true, features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_Devices_DeviceAndDriverInstallation",
+    "Win32_System_IO",
+] }
 
 [dev-dependencies]
 env_logger = "0.11.8"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ cargo msrv verify
 | `native_usb`  | Enable native USB feature                                              |   ❌    |
 | `hidapi`      | Enable HidApi feature                                                  |   ❌    |
 | `serial_port` | Enable Serial port feature                                             |   ❌    |
+| `usbprint`    | Enable Windows USB print driver (`usbprint.sys` via Win32 API)         |   ❌    |
 | `ui`          | Enable ui feature (UI components)                                      |   ❌    |
 | `full`        | Enable all features                                                    |   ❌    |
 
@@ -204,6 +205,40 @@ fn main() -> Result<()> {
         )?
         .feed()?
         .print_cut()?; // print() or print_cut() is mandatory to send the data to the printer
+
+    Ok(())
+}
+```
+
+### Windows USB print driver (with `usbprint` feature enabled, Windows only)
+
+Drives a POS printer through the standard Windows `usbprint.sys` kernel driver using the Win32
+API (`CreateFile` / `ReadFile` / `WriteFile`). No Zadig / WinUSB / libusb swap required — the
+device keeps working with the regular Windows print spooler at the same time.
+
+```rust,ignore
+use escpos::printer::Printer;
+use escpos::utils::*;
+use escpos::{driver::*, errors::Result};
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    // List USB printers exposed by usbprint.sys
+    for info in WindowsUsbPrintDriver::list()? {
+        println!("{} (VID={:?} PID={:?})", info.device_path, info.vendor_id, info.product_id);
+    }
+
+    // Option 1: open by USB vendor/product id
+    let driver = WindowsUsbPrintDriver::open_by_vid_pid(0x0525, 0xa700)?;
+
+    // Option 2: open by full device interface path
+    // let driver = WindowsUsbPrintDriver::open(r"\\?\USB#VID_0525&PID_A700#...")?;
+
+    Printer::new(driver, Protocol::default(), None)
+        .init()?
+        .writeln("Hello from Windows usbprint!")?
+        .print_cut()?;
 
     Ok(())
 }

--- a/examples/EXAMPLES.md
+++ b/examples/EXAMPLES.md
@@ -37,6 +37,7 @@ RUST_LOG=debug cargo run --example usb --features usb
 RUST_LOG=debug cargo run --example native_usb --features native_usb
 RUST_LOG=debug cargo run --example hidapi --features hidapi
 RUST_LOG=debug cargo run --example serial_port --features serial_port
+RUST_LOG=debug cargo run --example usbprint --features "usbprint,graphics"  # Windows only (usbprint.sys + sample image)
 ```
 
 ## UI examples

--- a/examples/usbprint.rs
+++ b/examples/usbprint.rs
@@ -1,0 +1,155 @@
+//! Windows USB print driver example.
+//!
+//! This example uses the built-in Windows `usbprint.sys` class driver through the Win32 API
+//! (no Zadig / WinUSB / libusb replacement needed). Run it on Windows only.
+//!
+//! With the `graphics` feature, it also prints the sample logo from
+//! `resources/images/rust-logo-small.png` (same asset as the `pictures` example).
+//!
+//! It queries printer status before printing: ESC/POS `DLE EOT` via `ReadFile` (one request at a
+//! time; batching multiple `DLE EOT` in one write can mis-align bulk-IN on `usbprint.sys`). On many
+//! setups the **first** bulk-IN byte is not a valid ESC/POS status (often `0x2B`); the example sends
+//! a throwaway `DLE EOT` and read to discard it before the real queries. Invalid bytes are logged
+//! instead of aborting. If reads return nothing, it falls back to `WindowsUsbPrintDriver::lpt_status`
+//! (`IOCTL_USBPRINT_GET_LPT_STATUS`).
+//!
+//! ```shell
+//! RUST_LOG=debug cargo run --example usbprint --features "usbprint,graphics"
+//! ```
+
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+fn main() -> escpos::errors::Result<()> {
+    use escpos::driver::*;
+    use escpos::errors::PrinterError;
+    use escpos::printer::Printer;
+    use escpos::utils::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    env_logger::init();
+
+    let devices = WindowsUsbPrintDriver::list()?;
+    if devices.is_empty() {
+        eprintln!("No USB print devices found (is the printer connected and using usbprint.sys?)");
+        return Ok(());
+    }
+
+    println!("Available Windows USB printers:");
+    for (i, d) in devices.iter().enumerate() {
+        println!(
+            "  [{i}] VID=0x{:04x?} PID=0x{:04x?} path={}",
+            d.vendor_id.unwrap_or(0),
+            d.product_id.unwrap_or(0),
+            d.device_path
+        );
+    }
+
+    // Open the first discovered printer. You can also use `open_by_vid_pid(vid, pid)` or
+    // `open(device_path)` for more control.
+    let driver = WindowsUsbPrintDriver::open(&devices[0].device_path)?;
+
+    println!("Status (before print):");
+    // Prime bulk-IN: the first byte read after open is often not ESC/POS (commonly 0x2B on
+    // usbprint.sys). Discard it so the next reads match the DLE EOT requests.
+    {
+        let (n, a): (u8, u8) = RealTimeStatusRequest::Printer.into();
+        driver.write(&[DLE, EOT, n, a])?;
+        driver.flush()?;
+        sleep(Duration::from_millis(15));
+        let mut discard = [0u8; 1];
+        let _ = driver.read(&mut discard);
+    }
+
+    // One `DLE EOT` per write/read.
+    let mut got_escpos = false;
+
+    for (req, label) in [
+        (RealTimeStatusRequest::Printer, "Printer"),
+        (RealTimeStatusRequest::RollPaperSensor, "Roll paper sensor"),
+    ] {
+        let (n, a): (u8, u8) = req.into();
+        driver.write(&[DLE, EOT, n, a])?;
+        driver.flush()?;
+        sleep(Duration::from_millis(15));
+
+        let mut b = [0u8; 1];
+        match driver.read(&mut b) {
+            Ok(0) => println!("  {label}: ReadFile returned 0 bytes"),
+            Ok(_) => match RealTimeStatusResponse::parse(req, b[0]) {
+                Ok(status) => {
+                    got_escpos = true;
+                    match req {
+                        RealTimeStatusRequest::Printer => {
+                            println!(
+                                "  ESC/POS — printer online: {}",
+                                status.get(&RealTimeStatusResponse::Online).unwrap_or(&false)
+                            );
+                        }
+                        RealTimeStatusRequest::RollPaperSensor => {
+                            println!(
+                                "  ESC/POS — roll paper near-end, paper adequate: {}",
+                                status
+                                    .get(&RealTimeStatusResponse::RollPaperNearEndSensorPaperAdequate)
+                                    .unwrap_or(&false)
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  {label}: status byte 0x{:02x} could not be parsed ({e}); ignoring",
+                        b[0]
+                    );
+                }
+            },
+            Err(e) => eprintln!("  {label}: ReadFile failed: {e}"),
+        }
+    }
+
+    if !got_escpos {
+        println!("  No usable ESC/POS status bytes; trying USBPRINT IOCTL…");
+        match driver.lpt_status() {
+            Ok(dw) => println!(
+                "  USBPRINT GET_LPT_STATUS: 0x{dw:08x} (IEEE-1284-style; see printer USB/status docs)"
+            ),
+            Err(e) => eprintln!("  GET_LPT_STATUS: {e}"),
+        }
+    }
+
+    let mut printer = Printer::new(driver, Protocol::default(), None);
+    printer
+        .debug_mode(Some(DebugMode::Dec))
+        .init()?
+        .writeln("Windows usbprint test")?;
+
+    #[cfg(feature = "graphics")]
+    {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/images/rust-logo-small.png");
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| PrinterError::Input("image path is not valid UTF-8".to_string()))?;
+        printer
+            .justify(JustifyMode::CENTER)?
+            .bit_image_option(path_str, BitImageOption::new(Some(128), None, BitImageSize::Normal)?)?
+            .feed()?;
+    }
+
+    #[cfg(not(feature = "graphics"))]
+    {
+        eprintln!("Tip: pass `--features \"usbprint,graphics\"` to print the sample logo image.");
+    }
+
+    printer.print_cut()?;
+
+    Ok(())
+}
+
+#[cfg(not(all(feature = "usbprint", target_os = "windows")))]
+fn main() {
+    eprintln!(
+        "The `usbprint` example must be built for Windows with `--features usbprint`.\n\
+         To print the sample image as well, also enable `graphics`:\n\
+         cargo run --example usbprint --features \"usbprint,graphics\""
+    );
+}

--- a/src/io/driver.rs
+++ b/src/io/driver.rs
@@ -10,6 +10,8 @@ use rusb::{Context, DeviceHandle, Direction, TransferType, UsbContext, UsbOption
 #[cfg(feature = "serial_port")]
 use serialport::SerialPort;
 use std::sync::{Arc, Mutex};
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+use std::{ffi::OsString, mem, os::windows::ffi::OsStringExt, ptr};
 use std::{
     fs::File,
     io::{self, Read, Write},
@@ -624,4 +626,389 @@ impl Driver for SerialPortDriver {
     fn flush(&self) -> Result<()> {
         Ok(self.port.lock()?.flush()?)
     }
+}
+
+// ================ Windows USB print driver ================
+
+/// Information about a USB printer discovered via the Windows `usbprint.sys` driver
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+#[derive(Debug, Clone)]
+pub struct WindowsUsbPrintInfo {
+    /// Device interface path (can be passed to `WindowsUsbPrintDriver::open`)
+    pub device_path: String,
+    /// USB Vendor ID parsed from the device path (when available)
+    pub vendor_id: Option<u16>,
+    /// USB Product ID parsed from the device path (when available)
+    pub product_id: Option<u16>,
+}
+
+/// Driver for a POS printer connected via the Windows `usbprint.sys` kernel driver.
+///
+/// This driver talks to the printer through the Windows Win32 API (`CreateFile` / `ReadFile` /
+/// `WriteFile`) by opening the device interface exposed by the standard `usbprint.sys` class
+/// driver. It is the recommended way to drive a USB ESC/POS printer on Windows without having
+/// to replace the driver with WinUSB/libusb (e.g. via Zadig).
+///
+/// **Status:** ESC/POS real-time status (`DLE EOT`) responses often do not appear as data from
+/// [`ReadFile`](https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-readfile) on
+/// this stack (you may see success with zero bytes read). For a status DWORD from the class
+/// driver, use [`WindowsUsbPrintDriver::lpt_status`].
+///
+/// The device interface class GUID used is `GUID_DEVINTERFACE_USBPRINT`
+/// (`{28D78FAD-5A12-11D1-AE5B-0000F803A8C2}`).
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+#[derive(Clone)]
+pub struct WindowsUsbPrintDriver {
+    device_path: String,
+    handle: Arc<Mutex<WinHandle>>,
+}
+
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+struct WinHandle(windows_sys::Win32::Foundation::HANDLE);
+
+// `HANDLE` is a raw pointer but Windows kernel handles are safe to move between threads and are
+// synchronized internally for the file I/O operations we perform.
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+unsafe impl Send for WinHandle {}
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+unsafe impl Sync for WinHandle {}
+
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+impl Drop for WinHandle {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        unsafe {
+            if self.0 as isize != 0 && self.0 as isize != INVALID_HANDLE_VALUE as isize {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+impl WindowsUsbPrintDriver {
+    // {28D78FAD-5A12-11D1-AE5B-0000F803A8C2}
+    const GUID_DEVINTERFACE_USBPRINT: windows_sys::core::GUID = windows_sys::core::GUID {
+        data1: 0x28d7_8fad,
+        data2: 0x5a12,
+        data3: 0x11d1,
+        data4: [0xae, 0x5b, 0x00, 0x00, 0xf8, 0x03, 0xa8, 0xc2],
+    };
+
+    /// Enumerate all USB printers currently exposed by the Windows `usbprint.sys` driver.
+    ///
+    /// Returns a list of [`WindowsUsbPrintInfo`] that can be used to open a specific printer by
+    /// passing its `device_path` to [`WindowsUsbPrintDriver::open`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use escpos::driver::WindowsUsbPrintDriver;
+    ///
+    /// for info in WindowsUsbPrintDriver::list().unwrap() {
+    ///     println!("{} (VID={:?}, PID={:?})", info.device_path, info.vendor_id, info.product_id);
+    /// }
+    /// ```
+    pub fn list() -> Result<Vec<WindowsUsbPrintInfo>> {
+        use windows_sys::Win32::Devices::DeviceAndDriverInstallation::{
+            DIGCF_DEVICEINTERFACE, DIGCF_PRESENT, SP_DEVICE_INTERFACE_DATA, SetupDiDestroyDeviceInfoList,
+            SetupDiEnumDeviceInterfaces, SetupDiGetClassDevsW, SetupDiGetDeviceInterfaceDetailW,
+        };
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+
+        unsafe {
+            let hdev = SetupDiGetClassDevsW(
+                &Self::GUID_DEVINTERFACE_USBPRINT,
+                ptr::null(),
+                ptr::null_mut(),
+                DIGCF_PRESENT | DIGCF_DEVICEINTERFACE,
+            );
+            if hdev as isize == 0 || hdev as isize == INVALID_HANDLE_VALUE as isize {
+                return Err(PrinterError::Io("SetupDiGetClassDevsW failed".to_string()));
+            }
+
+            let mut results = Vec::new();
+            let mut index: u32 = 0;
+            loop {
+                let mut iface_data: SP_DEVICE_INTERFACE_DATA = mem::zeroed();
+                iface_data.cbSize = mem::size_of::<SP_DEVICE_INTERFACE_DATA>() as u32;
+
+                let ok = SetupDiEnumDeviceInterfaces(
+                    hdev,
+                    ptr::null_mut(),
+                    &Self::GUID_DEVINTERFACE_USBPRINT,
+                    index,
+                    &mut iface_data,
+                );
+                if ok == 0 {
+                    break;
+                }
+                index += 1;
+
+                // First call to get required buffer size.
+                let mut required_size: u32 = 0;
+                SetupDiGetDeviceInterfaceDetailW(
+                    hdev,
+                    &iface_data,
+                    ptr::null_mut(),
+                    0,
+                    &mut required_size,
+                    ptr::null_mut(),
+                );
+                if required_size == 0 {
+                    continue;
+                }
+
+                // Allocate a raw buffer for the detail structure + variable length path.
+                let mut buffer: Vec<u8> = vec![0; required_size as usize];
+                // The detail struct's cbSize is the size of the fixed header (DWORD + first WCHAR),
+                // not the total buffer size. On 64-bit Windows this is 8 bytes due to alignment;
+                // on 32-bit Windows it is 6. Using size_of of the repr-C struct matches both.
+                let header_size = {
+                    #[repr(C)]
+                    struct DetailHeader {
+                        cb_size: u32,
+                        _device_path: [u16; 1],
+                    }
+                    mem::size_of::<DetailHeader>() as u32
+                };
+                // Write cbSize at the start of the buffer.
+                *(buffer.as_mut_ptr() as *mut u32) = header_size;
+
+                let ok = SetupDiGetDeviceInterfaceDetailW(
+                    hdev,
+                    &iface_data,
+                    buffer.as_mut_ptr() as *mut _,
+                    required_size,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                );
+                if ok == 0 {
+                    continue;
+                }
+
+                // DevicePath starts after the cbSize field at offset 4.
+                let path_ptr = buffer.as_ptr().add(4) as *const u16;
+                let mut len = 0usize;
+                while *path_ptr.add(len) != 0 {
+                    len += 1;
+                }
+                let slice = std::slice::from_raw_parts(path_ptr, len);
+                let device_path = OsString::from_wide(slice).to_string_lossy().into_owned();
+
+                let (vendor_id, product_id) = parse_vid_pid(&device_path);
+                results.push(WindowsUsbPrintInfo {
+                    device_path,
+                    vendor_id,
+                    product_id,
+                });
+            }
+
+            SetupDiDestroyDeviceInfoList(hdev);
+            Ok(results)
+        }
+    }
+
+    /// Open a Windows USB printer using its full device interface path as returned by
+    /// [`WindowsUsbPrintDriver::list`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use escpos::printer::Printer;
+    /// use escpos::utils::*;
+    /// use escpos::driver::*;
+    ///
+    /// let devices = WindowsUsbPrintDriver::list().unwrap();
+    /// let driver = WindowsUsbPrintDriver::open(&devices[0].device_path).unwrap();
+    /// let mut printer = Printer::new(driver, Protocol::default(), None);
+    /// ```
+    pub fn open(device_path: &str) -> Result<Self> {
+        use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        };
+
+        let wide: Vec<u16> = device_path.encode_utf16().chain(std::iter::once(0)).collect();
+
+        unsafe {
+            let handle = CreateFileW(
+                wide.as_ptr(),
+                (GENERIC_READ | GENERIC_WRITE) as u32,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                ptr::null_mut(),
+            );
+            if handle as isize == 0 || handle as isize == INVALID_HANDLE_VALUE as isize {
+                let err = io::Error::last_os_error();
+                return Err(PrinterError::Io(format!("CreateFileW failed for {device_path}: {err}")));
+            }
+
+            Ok(Self {
+                device_path: device_path.to_string(),
+                handle: Arc::new(Mutex::new(WinHandle(handle))),
+            })
+        }
+    }
+
+    /// Open the first USB printer exposed by `usbprint.sys` whose device path matches the given
+    /// USB vendor and product IDs.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use escpos::printer::Printer;
+    /// use escpos::utils::*;
+    /// use escpos::driver::*;
+    ///
+    /// let driver = WindowsUsbPrintDriver::open_by_vid_pid(0x0525, 0xa700).unwrap();
+    /// let mut printer = Printer::new(driver, Protocol::default(), None);
+    /// ```
+    pub fn open_by_vid_pid(vendor_id: u16, product_id: u16) -> Result<Self> {
+        let devices = Self::list()?;
+        let info = devices
+            .into_iter()
+            .find(|d| d.vendor_id == Some(vendor_id) && d.product_id == Some(product_id))
+            .ok_or_else(|| {
+                PrinterError::Io(format!(
+                    "No USB print device found with VID=0x{vendor_id:04x}, PID=0x{product_id:04x}"
+                ))
+            })?;
+        Self::open(&info.device_path)
+    }
+
+    /// Parallel-port-style status value from `usbprint.sys` via `IOCTL_USBPRINT_GET_LPT_STATUS`.
+    ///
+    /// This is the usual way to read a hardware status word on Windows when [`Driver::read`] does
+    /// not return ESC/POS `DLE EOT` reply bytes. Interpretation is IEEE-1284-related; see your
+    /// printer documentation for bit meanings.
+    pub fn lpt_status(&self) -> Result<u32> {
+        use windows_sys::Win32::System::IO::DeviceIoControl;
+
+        // usbprint.h: CTL_CODE(FILE_DEVICE_UNKNOWN, 12, METHOD_BUFFERED, FILE_ANY_ACCESS)
+        const FILE_DEVICE_UNKNOWN: u32 = 0x22;
+        const METHOD_BUFFERED: u32 = 0;
+        const FILE_ANY_ACCESS: u32 = 0;
+        const IOCTL_USBPRINT_GET_LPT_STATUS: u32 =
+            (FILE_DEVICE_UNKNOWN << 16) | (FILE_ANY_ACCESS << 14) | (12 << 2) | METHOD_BUFFERED;
+
+        let guard = self.handle.lock()?;
+        let mut status: u32 = 0;
+        let mut returned: u32 = 0;
+        let ok = unsafe {
+            DeviceIoControl(
+                guard.0,
+                IOCTL_USBPRINT_GET_LPT_STATUS,
+                ptr::null(),
+                0,
+                &mut status as *mut u32 as *mut _,
+                mem::size_of::<u32>() as u32,
+                &mut returned,
+                ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(PrinterError::Io(format!(
+                "IOCTL_USBPRINT_GET_LPT_STATUS failed: {}",
+                io::Error::last_os_error()
+            )));
+        }
+        Ok(status)
+    }
+}
+
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+impl Driver for WindowsUsbPrintDriver {
+    fn name(&self) -> String {
+        format!("Windows USB print ({})", self.device_path)
+    }
+
+    fn write(&self, data: &[u8]) -> Result<()> {
+        use windows_sys::Win32::Storage::FileSystem::WriteFile;
+
+        let guard = self.handle.lock()?;
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            let mut written: u32 = 0;
+            let ok = unsafe {
+                WriteFile(
+                    guard.0,
+                    remaining.as_ptr(),
+                    remaining.len() as u32,
+                    &mut written,
+                    ptr::null_mut(),
+                )
+            };
+            if ok == 0 {
+                return Err(PrinterError::Io(format!(
+                    "WriteFile failed: {}",
+                    io::Error::last_os_error()
+                )));
+            }
+            if written == 0 {
+                return Err(PrinterError::Io("WriteFile wrote 0 bytes".to_string()));
+            }
+            remaining = &remaining[written as usize..];
+        }
+        Ok(())
+    }
+
+    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        use windows_sys::Win32::Storage::FileSystem::ReadFile;
+
+        let guard = self.handle.lock()?;
+        let mut read: u32 = 0;
+        let ok = unsafe { ReadFile(guard.0, buf.as_mut_ptr(), buf.len() as u32, &mut read, ptr::null_mut()) };
+        if ok == 0 {
+            return Err(PrinterError::Io(format!(
+                "ReadFile failed: {}",
+                io::Error::last_os_error()
+            )));
+        }
+        Ok(read as usize)
+    }
+
+    fn flush(&self) -> Result<()> {
+        use windows_sys::Win32::Foundation::{ERROR_INVALID_FUNCTION, ERROR_NOT_SUPPORTED};
+        use windows_sys::Win32::Storage::FileSystem::FlushFileBuffers;
+
+        // `usbprint.sys` does not implement `IRP_MJ_FLUSH_BUFFERS`, so `FlushFileBuffers` returns
+        // ERROR_INVALID_FUNCTION (1) / ERROR_NOT_SUPPORTED (50). Since `WriteFile` on a USB bulk
+        // pipe has already handed the data to the stack, treat these as success (no-op flush).
+        let guard = self.handle.lock()?;
+        let ok = unsafe { FlushFileBuffers(guard.0) };
+        if ok == 0 {
+            let err = io::Error::last_os_error();
+            let code = err.raw_os_error().unwrap_or(0) as u32;
+            if code == ERROR_INVALID_FUNCTION || code == ERROR_NOT_SUPPORTED {
+                return Ok(());
+            }
+            return Err(PrinterError::Io(format!("FlushFileBuffers failed: {err}")));
+        }
+        Ok(())
+    }
+}
+
+/// Parse `VID_XXXX` and `PID_XXXX` (case insensitive) from a Windows device interface path.
+#[cfg(all(feature = "usbprint", target_os = "windows"))]
+fn parse_vid_pid(path: &str) -> (Option<u16>, Option<u16>) {
+    fn parse_hex_after(haystack: &str, needle: &str) -> Option<u16> {
+        let lower = haystack.to_ascii_lowercase();
+        let idx = lower.find(needle)?;
+        let start = idx + needle.len();
+        let hex: String = haystack[start..]
+            .chars()
+            .take_while(|c| c.is_ascii_hexdigit())
+            .take(4)
+            .collect();
+        if hex.is_empty() {
+            None
+        } else {
+            u16::from_str_radix(&hex, 16).ok()
+        }
+    }
+
+    (parse_hex_after(path, "vid_"), parse_hex_after(path, "pid_"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@
 //! | `native_usb`  | Enable native USB feature                                              |   ❌    |
 //! | `hidapi`      | Enable HidApi feature                                                  |   ❌    |
 //! | `serial_port` | Enable Serial port feature                                             |   ❌    |
+//! | `usbprint`    | Enable Windows USB print driver (`usbprint.sys` via Win32 API)         |   ❌    |
 //! | `ui`          | Enable ui feature (UI components)                                      |   ❌    |
 //! | `full`        | Enable all features                                                    |   ❌    |
 //!


### PR DESCRIPTION
## feat(windows): USB print driver via `usbprint.sys` + example

### Summary

Adds optional Windows support for ESC/POS printers through the built-in **`usbprint.sys`** stack (`CreateFile` / `WriteFile` / `ReadFile` / `DeviceIoControl`), so printing works without replacing the driver with WinUSB/libusb (e.g. Zadig).

### Changes

- **Feature:** `usbprint` (optional `windows-sys`), included in `full`.
- **`WindowsUsbPrintDriver`** (`src/io/driver.rs`):
  - Device enumeration via `GUID_DEVINTERFACE_USBPRINT`
  - `open` / `open_by_vid_pid`
  - Implements **`Driver`**
  - **`flush`:** treats `FlushFileBuffers` failures `ERROR_INVALID_FUNCTION` / `ERROR_NOT_SUPPORTED` as success when the driver does not implement flush
  - **`lpt_status()`:** `IOCTL_USBPRINT_GET_LPT_STATUS` for IEEE-1284-style status when ESC/POS bulk readback is unreliable
- **`examples/usbprint.rs`:** device list, status (ESC/POS + IOCTL fallback), demo print, optional `graphics` sample image
- **Docs:** feature table and example commands in README, `lib.rs`, and `examples/EXAMPLES.md` as applicable

### Notes

- ESC/POS real-time status via `ReadFile` can be inconsistent on `usbprint.sys`; the example uses separate `DLE EOT` round-trips and a priming read where needed.
- **`ReadFile` returning 0** for status is common on some setups; **`lpt_status`** is the supported Windows IOCTL path for a status DWORD.

### Testing

- **Printer:** Epson EU-m30, Windows with `usbprint.sys`
- **Checked:** print + cut, optional raster image (`graphics`), status flow in `examples/usbprint.rs`

### Try it

```bash
cargo run --example usbprint --features "usbprint,graphics"
```


**Disclaimer:** This PR (implementation, examples, and documentation) were produced with AI assistance. It was manually tested on an Epson TM-T30 (EU) under Windows with usbprint.sys.

Made with Opus 4.7