### PR TITLE
feat: extend FileDriver with method to pass in options

### DIFF
--- a/src/io/driver.rs
+++ b/src/io/driver.rs
@@ -12,6 +12,7 @@ use serialport::SerialPort;
 use std::sync::{Arc, Mutex};
 use std::{
     fs::File,
+    fs::OpenOptions,
     io::{self, Read, Write},
     net::{IpAddr, SocketAddr, TcpStream},
     path::Path,
@@ -182,6 +183,31 @@ impl FileDriver {
     /// ```
     pub fn open(path: &Path) -> Result<Self> {
         let file = File::options().read(true).append(true).open(path)?;
+        Ok(Self {
+            path: path.to_string_lossy().to_string(),
+            file: Arc::new(Mutex::new(file)),
+        })
+    }
+
+    /// Open the file driver using custom options
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use escpos::printer::Printer;
+    /// use escpos::utils::*;
+    /// use escpos::driver::*;
+    /// use std::fs::OpenOptions;
+    /// use std::path::Path;
+    ///
+    /// let path = Path::new("./foo/bar.txt");
+    /// let mut options = OpenOptions::new();
+    /// options.write(true).create(true).truncate(true);
+    /// let driver = FileDriver::open_with_options(&path, &options).unwrap();
+    /// let mut printer = Printer::new(driver, Protocol::default(), None);
+    /// ```
+    pub fn open_with_options(path: &Path, options: &OpenOptions) -> Result<Self> {
+        let file = options.open(path)?;
         Ok(Self {
             path: path.to_string_lossy().to_string(),
             file: Arc::new(Mutex::new(file)),


### PR DESCRIPTION
### Summary

Add method `FileDriver::open_with_options` to allow callers to control how the underlying file is opened (e.g., create, truncate, append) instead of being locked into the hardcoded read and append behaviour.

### Changes

- Add `FileDriver::open_with_options(&Path, &OpenOptions)` constructor
- Accepts a standard `std::fs::OpenOptions` reference, giving full control over file creation mode

### Motivation

I created a point-of-sale Tauri app years ago that used the `escposify` crate. Migrating to `escpos-rs` for more features was the best choice but it kept failing on the FileDriver opening. Looking into the existing `FileDriver::open` function, it uses `.read(true).append(true)` which only opens files for reading and writing but doesn't create one if it doesn't already exist. For printing to a file (e.g., `/dev/usb/lp0` or a new file), users need create and control over other options. This method exposes that without breaking existing API.

### Testing

- Tested with a shared EPSON TM-T88IV on Windows 11.