### PR TITLE
Add support for slip printing

### DIFF
--- a/src/domain/constants.rs
+++ b/src/domain/constants.rs
@@ -16,6 +16,13 @@ pub const ESC_HARDWARE_INIT: &[u8] = &[ESC, b'@'];
 pub const ESC_HARDWARE_RESET: &[u8] = &[ESC, b'?', LF, 0];
 pub const _ESC_HARDWARE_SELECT: &[u8] = &[ESC, b'=', 1]; // Unused
 
+// Print target
+pub const ESC_TARGET_ROLL: &[u8] = &[ESC, 0x63, 0x30, 0x01]; // Switch to roll printer
+pub const ESC_TARGET_SLIP: &[u8] = &[ESC, 0x63, 0x30, 0x04]; // Switch to matrix printer
+
+// Slip printer
+pub const ESC_SLIP_EJECT: &[u8] = &[0x0C];
+
 // Cash drawer
 pub const ESC_CASH_DRAWER_2: &[u8] = &[ESC, b'p', 0]; // Sends a pulse to pin 2
 pub const ESC_CASH_DRAWER_5: &[u8] = &[ESC, b'p', 1]; // Sends a pulse to pin 5

--- a/src/domain/protocol.rs
+++ b/src/domain/protocol.rs
@@ -46,6 +46,19 @@ impl Protocol {
         ESC_HARDWARE_RESET.to_vec()
     }
 
+    /// Change print target
+    pub(crate) fn target(&self, target: PrintTarget) -> Command {
+        match target {
+            PrintTarget::Roll => ESC_TARGET_ROLL.to_vec(),
+            PrintTarget::Slip => ESC_TARGET_SLIP.to_vec(),
+        }
+    }
+
+    /// Eject paper from slip
+    pub(crate) fn slip_eject(&self) -> Command {
+        ESC_SLIP_EJECT.to_vec()
+    }
+
     #[allow(dead_code)]
     /// Cancel
     pub(crate) fn cancel(&self) -> Command {

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -7,6 +7,23 @@ use core::fmt;
 /// Default characters per line
 pub const DEFAULT_CHARACTERS_PER_LINE: u8 = 42;
 
+/// Print target
+#[derive(Debug, Clone, Copy, Default)]
+pub enum PrintTarget {
+    #[default]
+    Roll,
+    Slip,
+}
+
+impl fmt::Display for PrintTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrintTarget::Roll => write!(f, "roll printer"),
+            PrintTarget::Slip => write!(f, "slip printer"),
+        }
+    }
+}
+
 /// Cash drawer pin
 #[derive(Debug, Clone, Copy)]
 pub enum CashDrawer {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -146,6 +146,20 @@ impl<D: Driver> Printer<D> {
         self
     }
 
+    /// Change the print target between slip and roll for supported printers
+    pub fn set_target(&mut self, target: PrintTarget) -> Result<&mut Self> {
+        let cmd = self.protocol.target(target);
+        self.command("Change print target", &[cmd])?;
+        Ok(self)
+    }
+
+    /// Eject the loaded paper from slip for supported printers
+    pub fn slip_eject(&mut self) -> Result<&mut Self> {
+        let cmd = self.protocol.slip_eject();
+        self.command("Eject slip paper", &[cmd])?;
+        Ok(self)
+    }
+
     /// Print the data
     ///
     /// All the instructions are sent at the same time to avoid printing partial data


### PR DESCRIPTION
Certain ESC/POS machines, such as the TM-H6000III use a slip printer (which I possess) in addition to the receipt printer. This commit allows the user to select between the receipt printer (PrintTarget::Roll) and the slip printer (PrintTarget::Slip) with Printer::set_target(target).
This pull request also adds support for slip ejection.
This code was tested with my TM-H6000III.

Main sources for the commands are
- the python-escpos source code
- https://ewr1.vultrobjects.com/public-files/filearchive/tpgdownloadables/A776/Guides/A776_PG00001B.pdf